### PR TITLE
Add drag and drop support

### DIFF
--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -9,7 +9,15 @@ import f3d, { type LogVerboseLevel } from "f3d";
 import { Icon } from "@iconify/react";
 import styles from "./styles.module.css";
 
-function initViewer(moduleRef: any, fileUrl: string, addLog: (message: string, level: "error" | "warning" | "info" | "debug") => void, setIsLoading: (isLoading: boolean) => void) {
+function initViewer(
+  moduleRef: any,
+  fileUrl: string,
+  addLog: (
+    message: string,
+    level: "error" | "warning" | "info" | "debug",
+  ) => void,
+  setIsLoading: (isLoading: boolean) => void,
+) {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   canvas.oncontextmenu = function (e) {
     e.preventDefault();

--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -9,8 +9,8 @@ import f3d, { type LogVerboseLevel } from "f3d";
 import { Icon } from "@iconify/react";
 import styles from "./styles.module.css";
 
-function initViewer(moduleRef, fileUrl, addLog, setIsLoading) {
-  const canvas = document.getElementById("canvas");
+function initViewer(moduleRef: any, fileUrl: string, addLog: (message: string, level: "error" | "warning" | "info" | "debug") => void, setIsLoading: (isLoading: boolean) => void) {
+  const canvas = document.getElementById("canvas") as HTMLCanvasElement;
   canvas.oncontextmenu = function (e) {
     e.preventDefault();
     e.stopPropagation();
@@ -24,7 +24,7 @@ function initViewer(moduleRef, fileUrl, addLog, setIsLoading) {
       const defaultFile = await fetch(fileUrl).then((b) => b.arrayBuffer());
 
       Module.Log.setVerboseLevel(Module.LogVerboseLevel.QUIET, false);
-      Module.Log.forward((level, message) => {
+      Module.Log.forward((level: LogVerboseLevel, message: string) => {
         if (level === Module.LogVerboseLevel.ERROR) addLog(message, "error");
         else if (level === Module.LogVerboseLevel.WARN)
           addLog(message, "warning");
@@ -114,20 +114,23 @@ function initViewer(moduleRef, fileUrl, addLog, setIsLoading) {
     });
 }
 
-function openStream(moduleRef, stream: Uint8Array) {
+function openStream(moduleRef: any, stream: Uint8Array) {
   const scene = moduleRef.current.engineInstance.getScene();
 
   scene.clear();
 
+  let result: { success: boolean; error?: string } = { success: true };
   try {
     scene.addBuffer(stream);
   } catch (e) {
-    console.error("Failed to load stream: " + e);
+    let [, errorMsg] = moduleRef.current.getExceptionMessage(e);
+    result = { success: false, error: errorMsg };
   }
 
   moduleRef.current.engineInstance.getWindow().getCamera().resetToBounds(0.9);
   moduleRef.current.engineInstance.getWindow().render();
   moduleRef.current.currentStream = stream;
+  return result;
 }
 
 interface F3DViewerProps {
@@ -135,7 +138,7 @@ interface F3DViewerProps {
 }
 
 const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
-  const moduleRef = useRef(null);
+  const moduleRef = useRef<any>(null);
   const [logs, setLogs] = useState<
     Array<{
       type: "debug" | "info" | "warning" | "error" | "command";
@@ -203,7 +206,7 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
           .triggerCommand(commandInput);
         moduleRef.current.engineInstance.getWindow().render();
       }
-    } catch (error) {
+    } catch (error: any) {
       addLog(`Error: ${error.message}`, "error");
     }
 
@@ -212,9 +215,9 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
 
   useImperativeHandle(ref, () => ({
     loadFile: (buffer: Uint8Array) => {
-      openStream(moduleRef, buffer);
+      return openStream(moduleRef, buffer);
     },
-    setUpDirection: (direction) => {
+    setUpDirection: (direction: "+Y" | "+Z") => {
       if (!moduleRef.current) return;
       // Set up direction in the engine options
       moduleRef.current.engineInstance

--- a/src/components/F3DViewer/styles.module.css
+++ b/src/components/F3DViewer/styles.module.css
@@ -1,5 +1,6 @@
 .viewer {
   min-height: 100%;
+  width: 100%;
   position: relative;
 }
 

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -26,6 +26,7 @@ $f3d_white: #F4F4F4;
 $f3d_blue: #788BFF;
 $f3d_yellow: #F9b208;
 $f3d_red: #F94306;
+$f3d_green: #7AFF7A;
 
 :root {
   /* Color Palette */
@@ -34,6 +35,13 @@ $f3d_red: #F94306;
   --accent-yellow: #{$f3d_yellow};
   --accent-blue: #{$f3d_blue};
   --accent-red: #{$f3d_red};
+  --accent-green: #{color.scale($f3d_green, $lightness: -50%)};
+
+  /* Make dimmed colors for accent colors */
+  --accent-yellow-dim: #{color.scale($f3d_yellow, $lightness: 80%)};
+  --accent-blue-dim: #{color.scale($f3d_blue, $lightness: 80%)};
+  --accent-red-dim: #{color.scale($f3d_red, $lightness: 80%)};
+  --accent-green-dim: #{color.scale($f3d_green, $lightness: 80%)};
 
   /* Typography */
   --font-primary: "Mulish", sans-serif;

--- a/src/pages/viewer.module.css
+++ b/src/pages/viewer.module.css
@@ -110,20 +110,68 @@
 
 /* File input */
 .fileInputGroup {
-  margin-bottom: 1rem;
-}
-.fileLabel {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  font-weight: 500;
+  gap: 0.35rem;
+}
+.fileLabel {
+  display: contents;
   cursor: pointer;
 }
 .fileInput {
   display: none;
 }
-.fileName {
+.fileButtonIcon {
+  width: 1.25em;
+  height: 1.25em;
+  vertical-align: middle;
+  margin-right: 0.4em;
+}
+.dragHint {
+  font-size: 0.75rem;
+  font-style: italic;
+  color: var(--ifm-color-emphasis-600);
+  text-align: center;
+}
+.fileNameBadge {
+  display: flex;
+  align-items: center;
+  gap: 0.35em;
   font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.3em 0.6em;
+  border-radius: 6px;
+  min-width: 0;
+}
+.fileNameBadge span {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.fileNameBadgeSuccess {
+  background: var(--accent-green-dim);
+  color: var(--accent-green);
+}
+.fileNameBadgeError {
+  background: var(--accent-red-dim);
+  color: var(--accent-red);
+}
+.fileNameBadgeLoading {
+  background: var(--accent-blue-dim);
+  color: var(--accent-blue);
+}
+.fileBadgeIcon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
+.fileBadgeSpinner {
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 }
 
 /* Up direction buttons */
@@ -202,6 +250,44 @@
   cursor: pointer;
   user-select: none;
   margin-left: 0.5em;
+}
+
+/* Drag-and-drop */
+.dropZone {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  height: 100%;
+}
+
+.dropZoneActive {
+  outline: 3px dashed var(--ifm-color-primary);
+  border-radius: 8px;
+}
+
+.dropOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  background: var(--bg-primary);
+  opacity: 0.8;
+  border-radius: 8px;
+  z-index: 10;
+  color: var(--text-primary);
+  font-size: 1.25rem;
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.dropIcon {
+  width: 3rem;
+  height: 3rem;
 }
 
 /* Progress bar container */

--- a/src/pages/viewer.tsx
+++ b/src/pages/viewer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, ReactNode } from "react";
+import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useLocation } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import useBaseUrl from "@docusaurus/useBaseUrl";
@@ -12,16 +12,31 @@ interface ViewerAppProps {
 }
 
 function ViewerApp({ model }: ViewerAppProps) {
-  const viewerRef = useRef(null);
+  const viewerRef = useRef<any>(null);
   const [upDirection, setUpDirection] = useState("+Z");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [fileName, setFileName] = useState(model || "f3d.vtp");
+  const [fileStatus, setFileStatus] = useState<"loading" | "success" | "error">("success");
+  const [fileError, setFileError] = useState<string | undefined>(undefined);
   const fileUrl = model || useBaseUrl("/data/f3d.vtp");
+
+  // Prevent the browser from accepting a dropped file outside the drop zone
+  useEffect(() => {
+    const prevent = (e: DragEvent) => e.preventDefault();
+    window.addEventListener("dragover", prevent);
+    window.addEventListener("drop", prevent);
+    return () => {
+      window.removeEventListener("dragover", prevent);
+      window.removeEventListener("drop", prevent);
+    };
+  }, []);
 
   // Callback for switch toggles
   const handleSwitchToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, checked } = event.target;
+    const { name, } = event.target;
 
-    const idOptionMappings = {
+    const idOptionMappings : Record<string, string> = {
       grid: "render.grid.enable",
       axis: "ui.axis",
       fxaa: "render.effect.antialiasing.enable",
@@ -33,64 +48,94 @@ function ViewerApp({ model }: ViewerAppProps) {
     viewerRef.current?.triggerCommand(`toggle ${idOptionMappings[name]}`);
   };
 
-  // Handle file selection
-  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
-    if (file) {
-      const fileNameSpan = document.getElementById("file-name");
-      if (fileNameSpan) fileNameSpan.textContent = file.name;
+  // Load a File object into the viewer
+  const loadFile = (file: File) => {
+    setFileName(file.name);
+    setFileStatus("loading");
 
-      const reader = new FileReader();
-      reader.addEventListener("loadend", (e) => {
-        const progressContainer = document.getElementById("progressContainer");
-        const progressFill = document.getElementById("progressFill");
-        const progressText = document.getElementById("progressText");
-
-        if (progressFill && progressText) {
-          progressFill.style.width = "100%";
-          progressText.textContent = "100%";
-        }
-
-        if (progressContainer) {
-          progressContainer.classList.add(styles.fadeOut);
-          setTimeout(() => {
-            progressContainer.style.display = "none";
-            progressContainer.classList.remove(styles.fadeOut);
-          }, 1000);
-        }
-
-        viewerRef.current?.loadFile(
-          new Uint8Array(reader.result as ArrayBuffer),
-        );
-      });
-
-      reader.addEventListener("progress", (evt) => {
-        const progressContainer = document.getElementById("progressContainer");
-        const progressFill = document.getElementById("progressFill");
-        const progressText = document.getElementById("progressText");
-
-        if (evt.lengthComputable && progressFill && progressText) {
-          const progress = Math.floor((100 * evt.loaded) / evt.total);
-          if (progressContainer) {
-            progressContainer.style.display = "flex";
-          }
-          progressFill.style.width = `${progress}%`;
-          progressText.textContent = `${progress}%`;
-        }
-      });
-
+    const reader = new FileReader();
+    reader.addEventListener("loadend", () => {
       const progressContainer = document.getElementById("progressContainer");
       const progressFill = document.getElementById("progressFill");
       const progressText = document.getElementById("progressText");
 
-      if (progressFill && progressText && progressContainer) {
-        progressFill.style.width = "0%";
-        progressText.textContent = "0%";
-        progressContainer.style.display = "flex";
+      if (progressFill && progressText) {
+        progressFill.style.width = "100%";
+        progressText.textContent = "100%";
       }
 
-      reader.readAsArrayBuffer(file);
+      if (progressContainer) {
+        progressContainer.classList.add(styles.fadeOut);
+        setTimeout(() => {
+          progressContainer.style.display = "none";
+          progressContainer.classList.remove(styles.fadeOut);
+        }, 1000);
+      }
+
+      const result = viewerRef.current?.loadFile(
+        new Uint8Array(reader.result as ArrayBuffer),
+      );
+      if (result.success === false) {
+        setFileStatus("error");
+        setFileError(result.error);
+      } else {
+        setFileStatus("success");
+        setFileError(undefined);
+      }
+    });
+
+    reader.addEventListener("error", () => {
+      setFileStatus("error");
+      setFileError("Failed to read file");
+    });
+
+    reader.addEventListener("progress", (evt) => {
+      const progressContainer = document.getElementById("progressContainer");
+      const progressFill = document.getElementById("progressFill");
+      const progressText = document.getElementById("progressText");
+
+      if (evt.lengthComputable && progressFill && progressText) {
+        const progress = Math.floor((100 * evt.loaded) / evt.total);
+        if (progressContainer) {
+          progressContainer.style.display = "flex";
+        }
+        progressFill.style.width = `${progress}%`;
+        progressText.textContent = `${progress}%`;
+      }
+    });
+
+    const progressContainer = document.getElementById("progressContainer");
+    const progressFill = document.getElementById("progressFill");
+    const progressText = document.getElementById("progressText");
+
+    if (progressFill && progressText && progressContainer) {
+      progressFill.style.width = "0%";
+      progressText.textContent = "0%";
+      progressContainer.style.display = "flex";
     }
+
+    reader.readAsArrayBuffer(file);
+  };
+
+  // Handle file selection when the dialog returns
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) loadFile(file);
+  };
+
+  // Drag-and-drop handlers
+  const handleDragEnter = (event: React.DragEvent) => {
+    setIsDragging(true);
+  };
+
+  const handleDragLeave = (event: React.DragEvent) => {
+    setIsDragging(false);
+  };
+
+  const handleDrop = (event: React.DragEvent) => {
+    setIsDragging(false);
+    const file = event.dataTransfer.files?.[0];
+    if (file) loadFile(file);
   };
 
   // Callback for up direction buttons
@@ -123,12 +168,27 @@ function ViewerApp({ model }: ViewerAppProps) {
                 onChange={handleFileChange}
               />
               <span className="button button--primary button--lg">
+                <Icon icon="material-symbols:folder-open" className={styles.fileButtonIcon} />
                 Open a file...
               </span>
-              <span className={styles.fileName} id="file-name">
-                {model || "f3d.vtp"}
-              </span>
             </label>
+            <span className={styles.dragHint}>
+              or drag &amp; drop a file
+            </span>
+            {(() => {
+              const badgeConfig = {
+                success: { mod: styles.fileNameBadgeSuccess, icon: "material-symbols:check-circle-outline", iconClass: styles.fileBadgeIcon },
+                error:   { mod: styles.fileNameBadgeError,   icon: "material-symbols:error-outline",        iconClass: styles.fileBadgeIcon },
+                loading: { mod: styles.fileNameBadgeLoading, icon: "material-symbols:progress-activity",    iconClass: `${styles.fileBadgeIcon} ${styles.fileBadgeSpinner}` },
+              };
+              const { mod, icon, iconClass } = badgeConfig[fileStatus];
+              return (
+                <span className={`${styles.fileNameBadge} ${mod}`} title={fileError}>
+                  <Icon icon={icon} className={iconClass} />
+                  <span>{fileName}</span>
+                </span>
+              );
+            })()}
           </div>
           <div className={styles.upDirectionGroup}>
             <button
@@ -240,7 +300,20 @@ function ViewerApp({ model }: ViewerAppProps) {
           >
             <Icon icon="material-symbols:settings" />
           </div>
-          <F3DViewer ref={viewerRef} fileUrl={fileUrl} />
+          <div
+            className={`${styles.dropZone} ${isDragging ? styles.dropZoneActive : ""}`}
+            onDragEnter={handleDragEnter}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            {isDragging && (
+              <div className={styles.dropOverlay}>
+                <Icon icon="material-symbols:upload-file" className={styles.dropIcon} />
+                <span>Drop file to open</span>
+              </div>
+            )}
+            <F3DViewer ref={viewerRef} fileUrl={fileUrl} />
+          </div>
         </main>
       </div>
       <div className={styles.progressContainer} id="progressContainer">

--- a/src/pages/viewer.tsx
+++ b/src/pages/viewer.tsx
@@ -17,7 +17,9 @@ function ViewerApp({ model }: ViewerAppProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [fileName, setFileName] = useState(model || "f3d.vtp");
-  const [fileStatus, setFileStatus] = useState<"loading" | "success" | "error">("success");
+  const [fileStatus, setFileStatus] = useState<"loading" | "success" | "error">(
+    "success",
+  );
   const [fileError, setFileError] = useState<string | undefined>(undefined);
   const fileUrl = model || useBaseUrl("/data/f3d.vtp");
 
@@ -34,9 +36,9 @@ function ViewerApp({ model }: ViewerAppProps) {
 
   // Callback for switch toggles
   const handleSwitchToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, } = event.target;
+    const { name } = event.target;
 
-    const idOptionMappings : Record<string, string> = {
+    const idOptionMappings: Record<string, string> = {
       grid: "render.grid.enable",
       axis: "ui.axis",
       fxaa: "render.effect.antialiasing.enable",
@@ -168,22 +170,38 @@ function ViewerApp({ model }: ViewerAppProps) {
                 onChange={handleFileChange}
               />
               <span className="button button--primary button--lg">
-                <Icon icon="material-symbols:folder-open" className={styles.fileButtonIcon} />
+                <Icon
+                  icon="material-symbols:folder-open"
+                  className={styles.fileButtonIcon}
+                />
                 Open a file...
               </span>
             </label>
-            <span className={styles.dragHint}>
-              or drag &amp; drop a file
-            </span>
+            <span className={styles.dragHint}>or drag &amp; drop a file</span>
             {(() => {
               const badgeConfig = {
-                success: { mod: styles.fileNameBadgeSuccess, icon: "material-symbols:check-circle-outline", iconClass: styles.fileBadgeIcon },
-                error:   { mod: styles.fileNameBadgeError,   icon: "material-symbols:error-outline",        iconClass: styles.fileBadgeIcon },
-                loading: { mod: styles.fileNameBadgeLoading, icon: "material-symbols:progress-activity",    iconClass: `${styles.fileBadgeIcon} ${styles.fileBadgeSpinner}` },
+                success: {
+                  mod: styles.fileNameBadgeSuccess,
+                  icon: "material-symbols:check-circle-outline",
+                  iconClass: styles.fileBadgeIcon,
+                },
+                error: {
+                  mod: styles.fileNameBadgeError,
+                  icon: "material-symbols:error-outline",
+                  iconClass: styles.fileBadgeIcon,
+                },
+                loading: {
+                  mod: styles.fileNameBadgeLoading,
+                  icon: "material-symbols:progress-activity",
+                  iconClass: `${styles.fileBadgeIcon} ${styles.fileBadgeSpinner}`,
+                },
               };
               const { mod, icon, iconClass } = badgeConfig[fileStatus];
               return (
-                <span className={`${styles.fileNameBadge} ${mod}`} title={fileError}>
+                <span
+                  className={`${styles.fileNameBadge} ${mod}`}
+                  title={fileError}
+                >
                   <Icon icon={icon} className={iconClass} />
                   <span>{fileName}</span>
                 </span>
@@ -308,7 +326,10 @@ function ViewerApp({ model }: ViewerAppProps) {
           >
             {isDragging && (
               <div className={styles.dropOverlay}>
-                <Icon icon="material-symbols:upload-file" className={styles.dropIcon} />
+                <Icon
+                  icon="material-symbols:upload-file"
+                  className={styles.dropIcon}
+                />
                 <span>Drop file to open</span>
               </div>
             )}


### PR DESCRIPTION
- Added drag and drop support
- Added a drop zone when the dragged file hover the viewer
- Added a label below the `Open file` button explaining drag and drop is possible
- Added an icon before `Open file`
- Improved the file name to reflect a state (`success`, `failure` and `loading`) with an icon and a color
- In case of failure, a tooltip describes the error (`.what()` exception text)
- Added some types when my IDE was complaining

AI disclosure:
I've been using Claude Sonnet to help me writing CSS code and AI auto-completion was active in VSCode.