### PR TITLE
Group react packages in the same PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
Avoid failures like the one in PR https://github.com/f3d-app/f3d-website/pull/108 by grouping `react` and `react-dom` in the same update.