### PR TITLE
Rework Gallery: Fix usability issues and improvements

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 import Heading from "@theme/Heading";
+import Link from "@docusaurus/Link";
+import { Icon } from "@iconify/react";
 import styles from "./styles.module.css";
 
 export default function HomepageFeatures(): ReactNode {
@@ -108,6 +110,18 @@ export default function HomepageFeatures(): ReactNode {
               </p>
             </div>
           </div>
+        </div>
+        <div className="text--center" style={{ marginTop: "3rem" }}>
+          <Link
+            className="button button--primary button--outline button--lg"
+            to="/gallery"
+          >
+            View more
+            <Icon
+              icon="material-symbols:arrow-forward-rounded"
+              className={styles.ctaIcon}
+            />
+          </Link>
         </div>
       </div>
     </section>

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -4,3 +4,9 @@
   padding: 6rem 0;
   width: 100%;
 }
+
+.ctaIcon {
+  font-size: 1.8rem;
+  margin-left: 0.8rem;
+  vertical-align: -0.25em;
+}

--- a/src/pages/gallery.module.css
+++ b/src/pages/gallery.module.css
@@ -5,8 +5,9 @@
   width: 700px;
 }
 
-/* Media wrapper — shows zoom cursor and accepts click */
+/* Media wrapper — positions expand button over media */
 .mediaWrapper {
+  position: relative;
   display: inline-block;
   cursor: zoom-in;
   border-radius: 8px;
@@ -15,6 +16,33 @@
 
 .mediaWrapper:focus-visible {
   outline: 2px solid var(--ifm-color-primary);
+}
+
+/* Expand button — same style as .lightboxClose */
+.expandButton {
+  position: absolute;
+  top: 0.35rem;
+  right: 0.35rem;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  padding: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.expandButton:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.expandButton svg {
+  width: 1.2rem;
+  height: 1.2rem;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.7));
 }
 
 /* Lightbox backdrop */

--- a/src/pages/gallery.module.css
+++ b/src/pages/gallery.module.css
@@ -4,3 +4,96 @@
   height: auto;
   width: 700px;
 }
+
+/* Media wrapper — shows zoom cursor and accepts click */
+.mediaWrapper {
+  display: inline-block;
+  cursor: zoom-in;
+  border-radius: 8px;
+  outline-offset: 3px;
+}
+
+.mediaWrapper:focus-visible {
+  outline: 2px solid var(--ifm-color-primary);
+}
+
+/* Lightbox backdrop */
+.lightboxBackdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.88);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+  padding: 1rem;
+  animation: fadeIn 0.15s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+/* Lightbox content wrapper */
+.lightboxContent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: scaleIn 0.15s ease;
+}
+
+@keyframes scaleIn {
+  from { transform: scale(0.95); opacity: 0; }
+  to   { transform: scale(1);    opacity: 1; }
+}
+
+/* Enlarged media inside lightbox */
+.lightboxMedia {
+  display: block;
+  max-width: 90vw;
+  max-height: 82vh;
+  width: auto;
+  height: auto;
+  border-radius: 8px;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6);
+}
+
+/* Close button — positioned above the media */
+.lightboxClose {
+  position: absolute;
+  top: -2.75rem;
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  cursor: pointer;
+  padding: 0.35rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: background 0.2s ease;
+}
+
+.lightboxClose:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.lightboxClose svg {
+  width: 1.5rem;
+  height: 1.5rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .lightboxMedia {
+    max-width: 95vw;
+    max-height: 72vh;
+  }
+
+  .lightboxClose {
+    top: -2.25rem;
+  }
+}

--- a/src/pages/gallery.module.css
+++ b/src/pages/gallery.module.css
@@ -116,6 +116,24 @@
 
 /* Responsive */
 @media (max-width: 768px) {
+  /*
+   * Sea-green Splide theme already adds padding: 3em on .splide and places arrows at
+   * left/right: 1em. Each arrow is 2.5em wide, so they bleed ~0.5em into the slide.
+   * Reposition arrows into the outer gutter and shrink them — no extra slide padding.
+   */
+  .gallerySplide :global(.splide__arrow--prev) {
+    left: 0;
+  }
+
+  .gallerySplide :global(.splide__arrow--next) {
+    right: 0;
+  }
+
+  .gallerySplide :global(.splide__arrow svg) {
+    width: 2em;
+    height: 2em;
+  }
+
   .lightboxMedia {
     max-width: 95vw;
     max-height: 72vh;

--- a/src/pages/gallery.module.css
+++ b/src/pages/gallery.module.css
@@ -117,9 +117,9 @@
 /* Responsive */
 @media (max-width: 768px) {
   /*
-   * Sea-green Splide theme already adds padding: 3em on .splide and places arrows at
-   * left/right: 1em. Each arrow is 2.5em wide, so they bleed ~0.5em into the slide.
-   * Reposition arrows into the outer gutter and shrink them — no extra slide padding.
+   * Sea-green Splide theme adds padding: 3em on .splide and places arrows at the 
+   * left/right: 1em. Each arrow is 2.5em wide, so they bleed around 0.5em into the slide.
+   * Reposition arrows into the outer gutter and shrink them, no extra slide padding.
    */
   .gallerySplide :global(.splide__arrow--prev) {
     left: 0;

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -11,7 +11,8 @@ import CodeBlock from "@theme/CodeBlock";
 import styles from "./gallery.module.css";
 import Link from "@docusaurus/Link";
 
-function toSlug(title: string): string {   //toSlug func. converts the slide titles as has URLs
+function toSlug(title: string): string {
+  //toSlug func. converts the slide titles as has URLs
   return title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -214,10 +215,11 @@ const galleryItems = [
 ];
 
 export default function Gallery(): ReactNode {
-
   const { siteConfig } = useDocusaurusContext();
-  const splideRef = useRef<{ splide: { go: (index: number) => void } } | null>(null);
-  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);       // null -> closed | number -> which item is enlarged | the counter for that entry
+  const splideRef = useRef<{ splide: { go: (index: number) => void } } | null>(
+    null,
+  );
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null); // null -> closed | number -> which item is enlarged | the counter for that entry
 
   useEffect(() => {
     const hash = window.location.hash.slice(1);
@@ -228,7 +230,7 @@ export default function Gallery(): ReactNode {
     }
   }, []);
 
-  useEffect(() => {               
+  useEffect(() => {
     if (lightboxIndex === null) return;
     document.body.style.overflow = "hidden";
     const onKeyDown = (e: KeyboardEvent) => {
@@ -253,7 +255,7 @@ export default function Gallery(): ReactNode {
       <div className="container">
         <Splide
           className={styles.gallerySplide}
-          ref={splideRef}               // updates the window.location.hash when slide is moved 
+          ref={splideRef} // updates the window.location.hash when slide is moved
           onMoved={(_splide, newIndex) => {
             window.location.hash = toSlug(galleryItems[newIndex].title);
           }}
@@ -261,7 +263,7 @@ export default function Gallery(): ReactNode {
             type: "loop",
             perPage: 1,
             gap: "2rem",
-            autoplay: false,     // Stops the automatic rotating, no need on pauseOnHover is autoplay is disabled
+            autoplay: false, // Stops the automatic rotating, no need on pauseOnHover is autoplay is disabled
             pagination: true,
             arrows: true,
           }}
@@ -278,7 +280,8 @@ export default function Gallery(): ReactNode {
                   tabIndex={0}
                   aria-label={`View ${item.title} in full size`}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") setLightboxIndex(idx);
+                    if (e.key === "Enter" || e.key === " ")
+                      setLightboxIndex(idx);
                   }}
                 >
                   {item.media}
@@ -360,8 +363,10 @@ export default function Gallery(): ReactNode {
               <Icon icon="material-symbols:close" />
             </button>
             {React.cloneElement(
-              galleryItems[lightboxIndex].media as React.ReactElement<{ className: string }>,
-              { className: styles.lightboxMedia }
+              galleryItems[lightboxIndex].media as React.ReactElement<{
+                className: string;
+              }>,
+              { className: styles.lightboxMedia },
             )}
           </div>
         </div>

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -3,12 +3,19 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import Admonition from "@theme/Admonition";
 import Heading from "@theme/Heading";
-import React from "react";
+import React, { useRef, useEffect } from "react";
 import "@splidejs/react-splide/css/sea-green";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./gallery.module.css";
 import Link from "@docusaurus/Link";
+
+function toSlug(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
 
 const galleryItems = [
   {
@@ -207,6 +214,17 @@ const galleryItems = [
 
 export default function Gallery(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
+  const splideRef = useRef<{ splide: { go: (index: number) => void } } | null>(null);
+
+  useEffect(() => {
+    const hash = window.location.hash.slice(1);
+    if (!hash || !splideRef.current) return;
+    const index = galleryItems.findIndex((item) => toSlug(item.title) === hash);
+    if (index !== -1) {
+      splideRef.current.splide.go(index);
+    }
+  }, []);
+
   return (
     <Layout
       title="Gallery"
@@ -218,6 +236,10 @@ export default function Gallery(): ReactNode {
       </div>
       <div className="container">
         <Splide
+          ref={splideRef}
+          onMoved={(_splide, newIndex) => {
+            window.location.hash = toSlug(galleryItems[newIndex].title);
+          }}
           options={{
             type: "loop",
             perPage: 1,

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -281,6 +281,14 @@ export default function Gallery(): ReactNode {
                   }}
                 >
                   {item.media}
+                  <button
+                    type="button"
+                    className={styles.expandButton}
+                    aria-label={`Expand ${item.title}`}
+                    tabIndex={-1}
+                  >
+                    <Icon icon="material-symbols:open-in-full" />
+                  </button>
                 </div>
                 <CodeBlock>{item.command}</CodeBlock>
               </section>

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -3,14 +3,15 @@ import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import Admonition from "@theme/Admonition";
 import Heading from "@theme/Heading";
-import React, { useRef, useEffect } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import "@splidejs/react-splide/css/sea-green";
 import { Splide, SplideSlide } from "@splidejs/react-splide";
+import { Icon } from "@iconify/react";
 import CodeBlock from "@theme/CodeBlock";
 import styles from "./gallery.module.css";
 import Link from "@docusaurus/Link";
 
-function toSlug(title: string): string {
+function toSlug(title: string): string {   //toSlug func. converts the slide titles as has URLs
   return title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
@@ -213,8 +214,10 @@ const galleryItems = [
 ];
 
 export default function Gallery(): ReactNode {
+
   const { siteConfig } = useDocusaurusContext();
   const splideRef = useRef<{ splide: { go: (index: number) => void } } | null>(null);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);       // null -> closed | number -> which item is enlarged | the counter for that entry
 
   useEffect(() => {
     const hash = window.location.hash.slice(1);
@@ -224,6 +227,19 @@ export default function Gallery(): ReactNode {
       splideRef.current.splide.go(index);
     }
   }, []);
+
+  useEffect(() => {               
+    if (lightboxIndex === null) return;
+    document.body.style.overflow = "hidden";
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setLightboxIndex(null);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.style.overflow = "";
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [lightboxIndex]);
 
   return (
     <Layout
@@ -236,7 +252,7 @@ export default function Gallery(): ReactNode {
       </div>
       <div className="container">
         <Splide
-          ref={splideRef}
+          ref={splideRef}               // updates the window.location.hash when slide is moved 
           onMoved={(_splide, newIndex) => {
             window.location.hash = toSlug(galleryItems[newIndex].title);
           }}
@@ -253,7 +269,19 @@ export default function Gallery(): ReactNode {
             <SplideSlide key={idx}>
               <section style={{ textAlign: "center" }}>
                 <Heading as="h2">{item.title}</Heading>
-                <div style={{ marginBottom: "1em" }}>{item.media}</div>
+                <div
+                  style={{ marginBottom: "1em" }}
+                  className={styles.mediaWrapper}
+                  onClick={() => setLightboxIndex(idx)}
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`View ${item.title} in full size`}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") setLightboxIndex(idx);
+                  }}
+                >
+                  {item.media}
+                </div>
                 <CodeBlock>{item.command}</CodeBlock>
               </section>
             </SplideSlide>
@@ -303,6 +331,32 @@ export default function Gallery(): ReactNode {
           </ul>
         </section>
       </div>
+      {lightboxIndex !== null && (
+        <div
+          className={styles.lightboxBackdrop}
+          onClick={() => setLightboxIndex(null)}
+          role="dialog"
+          aria-modal="true"
+          aria-label={galleryItems[lightboxIndex].title}
+        >
+          <div
+            className={styles.lightboxContent}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              className={styles.lightboxClose}
+              onClick={() => setLightboxIndex(null)}
+              aria-label="Close"
+            >
+              <Icon icon="material-symbols:close" />
+            </button>
+            {React.cloneElement(
+              galleryItems[lightboxIndex].media as React.ReactElement<{ className: string }>,
+              { className: styles.lightboxMedia }
+            )}
+          </div>
+        </div>
+      )}
     </Layout>
   );
 }

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -266,6 +266,7 @@ export default function Gallery(): ReactNode {
             autoplay: false, // Stops the automatic rotating, no need on pauseOnHover is autoplay is disabled
             pagination: true,
             arrows: true,
+            noDrag: "pre, pre *",
           }}
         >
           {galleryItems.map((item, idx) => (

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -222,8 +222,7 @@ export default function Gallery(): ReactNode {
             type: "loop",
             perPage: 1,
             gap: "2rem",
-            autoplay: true,
-            pauseOnHover: true,
+            autoplay: false,     // Stops the automatic rotating, no need on pauseOnHover is autoplay is disabled
             pagination: true,
             arrows: true,
           }}

--- a/src/pages/gallery.tsx
+++ b/src/pages/gallery.tsx
@@ -252,6 +252,7 @@ export default function Gallery(): ReactNode {
       </div>
       <div className="container">
         <Splide
+          className={styles.gallerySplide}
           ref={splideRef}               // updates the window.location.hash when slide is moved 
           onMoved={(_splide, newIndex) => {
             window.location.hash = toSlug(galleryItems[newIndex].title);


### PR DESCRIPTION
Closes #23 

Changes made to the `/gallery` page `gallery.tsx` are:
1.  Rotating for all devices have been disabled for better UX and easy copy/past
2. Direct hash-URLs for each gallery entry is added 
    - Current: Hash appears only after you navigate
3. Now we have the ability to click and open a larger view of the entry.
    <img width="1277" height="721" alt="Image" src="https://github.com/user-attachments/assets/321abd57-4e5f-4bd1-8fc5-7b0ba12c3091" />
5. Added a cta on the landing page labeled as `View more →` that links to the `/gallery` page.
    
    <img width="1280" height="725" alt="Image" src="https://github.com/user-attachments/assets/f1707675-3f79-4ed6-98eb-ed270efe33a9" />

**Suggested Changes:**
1. Placed an expand icon on top-right for better UX espically for hand held devices 
    <img width="1098" height="575" alt="Image" src="https://github.com/user-attachments/assets/90d08e8e-296f-4091-a7b4-d546da0ab91b" />

2. On mobile devices the arrows and the gallery entries are cramped up, provide approbate space for it.
   BEFORE: <img width="302" height="474" alt="Image" src="https://github.com/user-attachments/assets/ed453d43-3533-40bb-9b38-62ed89d8c283" /> AFTER: <img width="304" height="459" alt="Image" src="https://github.com/user-attachments/assets/e86787d3-f9ba-4225-9269-ff478188673a" /> 