### PR TITLE
Disable SSAO mobile

### DIFF
--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -81,9 +81,13 @@ function initViewer(
       moduleRef.current.engineInstance
         .getOptions()
         .toggle("render.effect.tone_mapping");
-      moduleRef.current.engineInstance
-        .getOptions()
-        .toggle("render.effect.ambient_occlusion");
+      // SSAO is memory-bandwidth heavy and causes thermal throttling on mobile GPUs,
+      // so skip enabling it by default on narrow viewports.
+      if (!window.matchMedia("(max-width: 768px)").matches) {
+        moduleRef.current.engineInstance
+          .getOptions()
+          .toggle("render.effect.ambient_occlusion");
+      }
       moduleRef.current.engineInstance
         .getOptions()
         .toggle("render.hdri.ambient");

--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -81,12 +81,20 @@ function initViewer(
       moduleRef.current.engineInstance
         .getOptions()
         .toggle("render.effect.tone_mapping");
-      // SSAO is memory-bandwidth heavy and causes thermal throttling on mobile GPUs,
-      // so skip enabling it by default on narrow viewports.
+      // Workaround: SSAO, grid and reflection are disabled on mobile by default.
+      // SSAO is memory-bandwidth heavy and causes thermal throttling on mobile GPUs.
+      // Grid + reflection cause depth artifacts (jagged edges) when SSAO is off on mobile.
+      // Users can still enable them manually via the settings panel.
       if (!window.matchMedia("(max-width: 768px)").matches) {
         moduleRef.current.engineInstance
           .getOptions()
           .toggle("render.effect.ambient_occlusion");
+        moduleRef.current.engineInstance
+          .getOptions()
+          .toggle("render.grid.enable");
+        moduleRef.current.engineInstance
+          .getOptions()
+          .setAsString("render.grid.reflection", "0.5");
       }
       moduleRef.current.engineInstance
         .getOptions()
@@ -94,13 +102,6 @@ function initViewer(
 
       // display widgets
       moduleRef.current.engineInstance.getOptions().toggle("ui.axis");
-      moduleRef.current.engineInstance
-        .getOptions()
-        .toggle("render.grid.enable");
-
-      moduleRef.current.engineInstance
-        .getOptions()
-        .setAsString("render.grid.reflection", "0.5");
 
       // default to +Z
       moduleRef.current.engineInstance

--- a/src/pages/viewer.tsx
+++ b/src/pages/viewer.tsx
@@ -17,7 +17,10 @@ function ViewerApp({ model }: ViewerAppProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   // Default true (SSR-safe); corrected to false on mobile after hydration.
+  // Workaround: grid + reflection cause depth artifacts on mobile when SSAO is off.
   const [ssaoDefault, setSsaoDefault] = useState(true);
+  const [gridDefault, setGridDefault] = useState(true);
+  const [reflectionDefault, setReflectionDefault] = useState(true);
   const [fileName, setFileName] = useState(model || "f3d.vtp");
   const [fileStatus, setFileStatus] = useState<"loading" | "success" | "error">(
     "success",
@@ -27,7 +30,10 @@ function ViewerApp({ model }: ViewerAppProps) {
 
   // window is unavailable during SSR, so detect mobile only after mount.
   useEffect(() => {
-    setSsaoDefault(!window.matchMedia("(max-width: 768px)").matches);
+    const isDesktop = !window.matchMedia("(max-width: 768px)").matches;
+    setSsaoDefault(isDesktop);
+    setGridDefault(isDesktop);
+    setReflectionDefault(isDesktop);
   }, []);
 
   // Prevent the browser from accepting a dropped file outside the drop zone
@@ -254,22 +260,25 @@ function ViewerApp({ model }: ViewerAppProps) {
           <div className={styles.sectionLabel}>Widgets</div>
           <div className={styles.switchField}>
             <input
+              key={String(gridDefault)}
               id="grid"
               type="checkbox"
               name="grid"
               className={styles.switchInput}
-              defaultChecked
+              defaultChecked={gridDefault}
               onChange={handleSwitchToggle}
             />
             <label htmlFor="grid">Grid</label>
           </div>
           <div className={styles.switchField}>
             <input
+              key={`reflection-${String(reflectionDefault)}`}
               id="reflection"
               type="checkbox"
               name="reflection"
               className={styles.switchInput}
-              defaultChecked
+              defaultChecked={reflectionDefault}
+              disabled={!gridDefault}
               onChange={handleSwitchToggle}
             />
             <label htmlFor="reflection">Reflection</label>

--- a/src/pages/viewer.tsx
+++ b/src/pages/viewer.tsx
@@ -307,7 +307,8 @@ function ViewerApp({ model }: ViewerAppProps) {
               type="checkbox"
               name="ssao"
               className={styles.switchInput}
-              defaultChecked
+              // Keep the checkbox in sync with the engine: SSAO is off by default on mobile.
+              defaultChecked={!window.matchMedia("(max-width: 768px)").matches}
               onChange={handleSwitchToggle}
             />
             <label htmlFor="ssao">Ambient occlusion</label>

--- a/src/pages/viewer.tsx
+++ b/src/pages/viewer.tsx
@@ -16,12 +16,19 @@ function ViewerApp({ model }: ViewerAppProps) {
   const [upDirection, setUpDirection] = useState("+Z");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  // Default true (SSR-safe); corrected to false on mobile after hydration.
+  const [ssaoDefault, setSsaoDefault] = useState(true);
   const [fileName, setFileName] = useState(model || "f3d.vtp");
   const [fileStatus, setFileStatus] = useState<"loading" | "success" | "error">(
     "success",
   );
   const [fileError, setFileError] = useState<string | undefined>(undefined);
   const fileUrl = model || useBaseUrl("/data/f3d.vtp");
+
+  // window is unavailable during SSR, so detect mobile only after mount.
+  useEffect(() => {
+    setSsaoDefault(!window.matchMedia("(max-width: 768px)").matches);
+  }, []);
 
   // Prevent the browser from accepting a dropped file outside the drop zone
   useEffect(() => {
@@ -303,12 +310,13 @@ function ViewerApp({ model }: ViewerAppProps) {
           </div>
           <div className={styles.switchField}>
             <input
+              key={String(ssaoDefault)}
               id="ssao"
               type="checkbox"
               name="ssao"
               className={styles.switchInput}
               // Keep the checkbox in sync with the engine: SSAO is off by default on mobile.
-              defaultChecked={!window.matchMedia("(max-width: 768px)").matches}
+              defaultChecked={ssaoDefault}
               onChange={handleSwitchToggle}
             />
             <label htmlFor="ssao">Ambient occlusion</label>


### PR DESCRIPTION
Closes #38 

Changes made small:
1. `F3DViewer/index.tsx`: wrap the `toggle("render.effect.ambient_occlusion")` call in a mobile check. All other effects (antialiasing, tone mapping, HDRI ambient) stay unconditional.
2. `viewer.tsx`: change default checked on the SSAO input from a hardcoded `true` to `!window.matchMedia("(max-width: 768px)").matches`. This keeps the UI checkbox in sync with the engine's actual state. 
---
3. Add a workaround for, edges and artifacts – turned `SSOA + Grid: OFF` on mobile for default, that can later be individually turned `ON`