### PR TITLE
Forward key bindings

### DIFF
--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -19,6 +19,10 @@ function initViewer(
   setIsLoading: (isLoading: boolean) => void,
 ) {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+  // Focus the canvas when the user clicks it so keyboard events are forwarded
+  canvas.addEventListener("mousedown", () => canvas.focus());
+
   canvas.oncontextmenu = function (e) {
     e.preventDefault();
     e.stopPropagation();
@@ -53,9 +57,6 @@ function initViewer(
       moduleRef.current.engineInstance
         .getOptions()
         .setAsString("ui.loader_progress", "true");
-      moduleRef.current.engineInstance
-        .getOptions()
-        .setAsString("ui.animation_progress", "true");
       moduleRef.current.engineInstance
         .getOptions()
         .setAsString("scene.animation.autoplay", "true");
@@ -122,6 +123,8 @@ function initViewer(
 
       moduleRef.current.engineInstance.getInteractor().start();
 
+      moduleRef.current.canvas.focus(); // focus by default
+
       // Hide loading screen
       setIsLoading(false);
     })
@@ -167,6 +170,7 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
   const [isLogWindowOpen, setIsLogWindowOpen] = useState(false);
   const [commandInput, setCommandInput] = useState("");
   const logEndRef = useRef<HTMLDivElement>(null);
+  const commandInputRef = useRef<HTMLInputElement>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [severityFilters, setSeverityFilters] = useState({
     error: true,
@@ -207,6 +211,13 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
       }
     }
   }, [logs]);
+
+  // When the log window opens, focus the command input so the user can type immediately
+  useEffect(() => {
+    if (isLogWindowOpen) {
+      commandInputRef.current?.focus();
+    }
+  }, [isLogWindowOpen]);
 
   // Handle command submission
   const handleCommandSubmit = (e: React.FormEvent) => {
@@ -254,11 +265,19 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
 
   useEffect(() => {
     initViewer(moduleRef, fileUrl, addLog, setIsLoading);
+
+    // Open the log window when escape is pressed
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+    canvas.addEventListener("keydown", (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setIsLogWindowOpen(true);
+      }
+    });
   }, [fileUrl]);
 
   return (
     <div className={styles.viewer}>
-      <canvas id="canvas"></canvas>
+      <canvas id="canvas" tabIndex={0}></canvas>
 
       {isLoading && (
         <div className={styles.loadingScreen}>
@@ -273,7 +292,7 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
       {!isLoading && !isLogWindowOpen && (
         <button
           className={styles.logToggle}
-          onClick={() => setIsLogWindowOpen(!isLogWindowOpen)}
+          onClick={() => setIsLogWindowOpen(true)}
           aria-label="Toggle log window"
           title="Console"
         >
@@ -341,6 +360,7 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
           </div>
           <form className={styles.logInput} onSubmit={handleCommandSubmit}>
             <input
+              ref={commandInputRef}
               type="text"
               placeholder="Enter command..."
               value={commandInput}
@@ -349,6 +369,18 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
                 if (e.key === "Enter") {
                   e.preventDefault();
                   handleCommandSubmit(e);
+                } else if (e.key === "Escape") {
+                  e.stopPropagation();
+                  e.preventDefault();
+                  if (commandInput !== "") {
+                    setCommandInput("");
+                  } else {
+                    setIsLogWindowOpen(false);
+                    const c = document.getElementById(
+                      "canvas",
+                    ) as HTMLCanvasElement;
+                    if (c) c.focus();
+                  }
                 }
               }}
               className={styles.commandInput}

--- a/src/components/F3DViewer/styles.module.css
+++ b/src/components/F3DViewer/styles.module.css
@@ -4,6 +4,13 @@
   position: relative;
 }
 
+/* Canvas focus indicator */
+.viewer canvas:focus {
+  outline: none;
+  border: 1px solid var(--ifm-color-primary);
+  border-radius: 6px;
+}
+
 /* Loading screen */
 .loadingScreen {
   position: absolute;
@@ -52,8 +59,8 @@
 /* Log window toggle button */
 .logToggle {
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 1rem;
+  right: 1rem;
   width: 3rem;
   height: 3rem;
   border-radius: 50%;


### PR DESCRIPTION
- Remove animation progress option since it relies on imgui now (a native animation bar will be handled later)
- Handle canvas focus to allow key bindings to properly propagate to the wasm interactor
- Add auto-focus to the console window command input after opening
- When pressing ESCAPE when canvas has focus, open the console
- When pressing ESCAPE when command input has focus clears the input or close the console when input is empty to match the native application behavior.
- Add an outline when the viewer has focus to inform the user the key presses are intercepted by the interactor
- Moved the console open button slightly to avoid overlap with the viewer outline