### PR TITLE
Clean up F3DViewer lifecycle and triggerCommand calls

### DIFF
--- a/src/components/F3DViewer/index.tsx
+++ b/src/components/F3DViewer/index.tsx
@@ -20,9 +20,6 @@ function initViewer(
 ) {
   const canvas = document.getElementById("canvas") as HTMLCanvasElement;
 
-  // Focus the canvas when the user clicks it so keyboard events are forwarded
-  canvas.addEventListener("mousedown", () => canvas.focus());
-
   canvas.oncontextmenu = function (e) {
     e.preventDefault();
     e.stopPropagation();
@@ -233,7 +230,7 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
       if (moduleRef.current) {
         moduleRef.current.engineInstance
           .getInteractor()
-          .triggerCommand(commandInput);
+          .triggerCommand(commandInput, true);
         moduleRef.current.engineInstance.getWindow().render();
       }
     } catch (error: any) {
@@ -257,22 +254,40 @@ const F3DViewer = forwardRef<any, F3DViewerProps>(({ fileUrl }, ref) => {
     },
     triggerCommand: (command: string) => {
       if (!moduleRef.current) return;
-      moduleRef.current.engineInstance.getInteractor().triggerCommand(command);
+      moduleRef.current.engineInstance
+        .getInteractor()
+        .triggerCommand(command, true);
       moduleRef.current.engineInstance.getWindow().render();
     },
     addLog: addLog,
   }));
 
   useEffect(() => {
-    initViewer(moduleRef, fileUrl, addLog, setIsLoading);
+    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+
+    // Focus the canvas when the user clicks it so keyboard events are forwarded
+    const handleMouseDown = () => canvas.focus();
+    canvas.addEventListener("mousedown", handleMouseDown);
 
     // Open the log window when escape is pressed
-    const canvas = document.getElementById("canvas") as HTMLCanvasElement;
-    canvas.addEventListener("keydown", (e: KeyboardEvent) => {
+    const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         setIsLogWindowOpen(true);
       }
-    });
+    };
+    canvas.addEventListener("keydown", handleKeyDown);
+
+    initViewer(moduleRef, fileUrl, addLog, setIsLoading);
+
+    return () => {
+      canvas.removeEventListener("mousedown", handleMouseDown);
+      canvas.removeEventListener("keydown", handleKeyDown);
+      if (moduleRef.current?.engineInstance) {
+        moduleRef.current.engineInstance.getInteractor().requestStop();
+        moduleRef.current.engineInstance[Symbol.dispose]();
+        moduleRef.current.engineInstance = null;
+      }
+    };
   }, [fileUrl]);
 
   return (


### PR DESCRIPTION
### About
- Add a `useEffect` cleanup in F3DViewer so the engine is stopped/disposed and canvas event listeners are removed on unmount.
- Pass the second keepComments argument to triggerCommand to match the current f3d WASM API.

While investigating #147 (axis toggle), I found a couple of website-side issues that are worth fixing independently:
- Lifecycle cleanup: `initViewer` created an engine and attached canvas listeners, but the effect never cleaned them up. On remount this can leave listeners (and potentially engine instances) behind.
- `triggerCommand` signature, after the f3d package update, the WASM binding expects (command, keepComments). Call sites were only passing the command string.